### PR TITLE
manifest - work only on .md files

### DIFF
--- a/_manifest/manifest_generator.py
+++ b/_manifest/manifest_generator.py
@@ -39,8 +39,12 @@ def get_manifest():
 def get_file_paths(path_prefix):
     file_names = os.listdir(path_prefix)
     full_paths = []
+    index_suffix = 1
     for name in file_names:
         full_path = os.path.join(path_prefix, name)
+        if os.path.splitext(full_path)[index_suffix] != '.md':
+            logger.info(f'Ignoring file {name}')
+            continue
         full_paths.append(full_path)
     return full_paths
 

--- a/_manifest/readme.md
+++ b/_manifest/readme.md
@@ -24,6 +24,7 @@ python3 _manifest/manifest_generator_test.py
 
 
 ### Changelog:
-
+- **0.0.2**:
+  - Ignore files that aren't `.md`.
 - **0.0.1**:
   - Initial release.


### PR DESCRIPTION
Add condition to ignore files that aren't .md files