### PR TITLE
fix scripts to handle prs that are only delete

### DIFF
--- a/_metadata_validation/get_pr_files.py
+++ b/_metadata_validation/get_pr_files.py
@@ -26,8 +26,7 @@ def get_pr_files():
         if len(files) == 0:
             break
         for file in files:
-            if file[status_field] != 'removed':
-                files_in_pr.append(file[file_name_field])
+            files_in_pr.append(file[file_name_field])
         page_number += 1
 
     files_str = ''

--- a/_metadata_validation/validate_metadata.py
+++ b/_metadata_validation/validate_metadata.py
@@ -14,10 +14,14 @@ logger = logging.getLogger()
 
 def validate_changed_files():
     error_counter = 0
-    changed_files = get_changed_files()
+    changed_files, removed_files = get_changed_files()
     if len(changed_files) == 0:
-        logger.error('Could not find changed files, exiting')
-        exit(1)
+        if len(removed_files) > 0:
+            logger.info('PR only deletes files')
+            exit(0)
+        else:
+            logger.error('Could not find changed files, exiting')
+            exit(1)
     logger.info(f'Files to scan: {changed_files}')
     files_to_unique_fields = get_files_to_unique_fields()
     if len(files_to_unique_fields) == 0:
@@ -96,11 +100,15 @@ def get_changed_files():
     files_str = files_str.replace(' ', '')
     files_arr = files_str.split(',')
     files_to_track = []
+    removed_files = []
     for file in files_arr:
         docs_path = os.getenv(consts.ENV_DOCS_PREFIX, consts.DOCS_PATH)
+        if not os.path.isfile(docs_path):
+            removed_files.append(file)
+            continue
         if file.startswith(docs_path) and file.endswith('.md'):
             files_to_track.append(file)
-    return files_to_track
+    return files_to_track, removed_files
 
 
 def get_files_to_unique_fields():

--- a/_metadata_validation/validate_metadata.py
+++ b/_metadata_validation/validate_metadata.py
@@ -96,14 +96,14 @@ def print_missing_fields(file_metadata):
 def get_changed_files():
     files_str = os.getenv(consts.ENV_FILES_TO_TRACK, '')
     if files_str == '':
-        return []
+        return [], []
     files_str = files_str.replace(' ', '')
     files_arr = files_str.split(',')
     files_to_track = []
     removed_files = []
     for file in files_arr:
         docs_path = os.getenv(consts.ENV_DOCS_PREFIX, consts.DOCS_PATH)
-        if not os.path.isfile(docs_path):
+        if not os.path.isfile(file):
             removed_files.append(file)
             continue
         if file.startswith(docs_path) and file.endswith('.md'):

--- a/_metadata_validation/validate_metadata_test.py
+++ b/_metadata_validation/validate_metadata_test.py
@@ -148,13 +148,13 @@ class TestValidateMetadata(unittest.TestCase):
     def test_get_changed_files(self):
         changed_set = f'{self.PATH_PREFIX}valid-sample.md'
         os.environ[validate_metadata.consts.ENV_FILES_TO_TRACK] = changed_set
-        changed_files = validate_metadata.get_changed_files()
+        changed_files, removed_files = validate_metadata.get_changed_files()
         self.assertEqual(len(changed_files), 1)
         self.assertEqual(changed_files[0], changed_set)
 
     def test_get_changed_files_empty(self):
         os.environ[validate_metadata.consts.ENV_FILES_TO_TRACK] = ''
-        changed_files = validate_metadata.get_changed_files()
+        changed_files, removed_files = validate_metadata.get_changed_files()
         self.assertEqual(len(changed_files), 0)
 
     def test_get_file_metadata(self):


### PR DESCRIPTION
Currently, if opening a PR that contains only a delete of doc, the manifest workflow fails.
This PR should handle it.