### PR TITLE
Added missing permissions to failed PR validation step

### DIFF
--- a/.github/workflows/pr_validate.yaml
+++ b/.github/workflows/pr_validate.yaml
@@ -104,6 +104,8 @@ jobs:
           commit_message: 'auto generated manifest'
           commit_options: "--no-gpg-sign"
           push_options: '--force'
+        permissions:
+          contents: 'write'          
       - name: Manifest update success
         if: steps.create_manifest.outputs.skip_next_step != 'true' && steps.run_validation.outputs.skip_next_step != 'true'
         run: |

--- a/.github/workflows/pr_validate.yaml
+++ b/.github/workflows/pr_validate.yaml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MANIFEST_PATH: '_manifest/validation_manifest.json'
+    permissions:
+      contents: 'write'
+      metadata: 'read'
+      packages: 'read'
     steps:
       - name: Checkout PR
         uses: actions/checkout@v4
@@ -103,9 +107,7 @@ jobs:
           file_pattern: './static/manifest.json'
           commit_message: 'auto generated manifest'
           commit_options: "--no-gpg-sign"
-          push_options: '--force'
-        permissions:
-          contents: 'write'          
+          push_options: '--force'      
       - name: Manifest update success
         if: steps.create_manifest.outputs.skip_next_step != 'true' && steps.run_validation.outputs.skip_next_step != 'true'
         run: |

--- a/.github/workflows/pr_validate.yaml
+++ b/.github/workflows/pr_validate.yaml
@@ -13,7 +13,6 @@ jobs:
       MANIFEST_PATH: '_manifest/validation_manifest.json'
     permissions:
       contents: 'write'
-      metadata: 'read'
       packages: 'read'
     steps:
       - name: Checkout PR


### PR DESCRIPTION
The 'https://github.com/stefanzweifel/git-auto-commit-action' project requires specific permissions, since they are missing the workflow fails with access denied.

https://logzio.atlassian.net/browse/CORE-351