### PR TITLE
Fix otel_config.yaml indentation and correct URL in endpoint

### DIFF
--- a/docs/shipping/Operating-Systems/linux.md
+++ b/docs/shipping/Operating-Systems/linux.md
@@ -109,14 +109,14 @@ exporters:
     headers:
       user-agent: logzio-linux-logs
   prometheusremotewrite:
-    endpoint: https:<<LISTENER-HOST>>:8053
+    endpoint: https://<<LISTENER-HOST>>:8053
     headers:
       Authorization: Bearer <<PROMETHEUS-METRICS-SHIPPING-TOKEN>>
       user-agent: logzio-linux-metrics
     resource_to_telemetry_conversion:
       enabled: true
     target_info:
-        enabled: false
+      enabled: false
 service:
   pipelines:
     logs:


### PR DESCRIPTION
This PR addresses two issues in the otel_config.yaml documentation:
  - Corrected the YAML indentation.
  - Fixed the missing '//' in the endpoint URL of prometheusremotewrite.

