### PR TITLE
Add Documentation for ECS Setup with OpenTelemetry for Java, Python, and Node.js

### DIFF
--- a/docs/shipping/Code/java.md
+++ b/docs/shipping/Code/java.md
@@ -1153,3 +1153,387 @@ Supported values for `otel.traces.sampler` are
 ### Viewing Traces in Logz.io
 
 Give your traces time to process, after which they'll be available in your [Tracing](https://app.logz.io/#/dashboard/jaeger) dashboard.
+
+## Java Application Setup for ECS Service with OpenTelemetry
+
+This document provides step-by-step instructions for setting up a Java application on Amazon ECS, using OpenTelemetry to send tracing data directly to your Logz.io account.
+
+### **Prerequisites**
+
+Before you begin, ensure you have the following prerequisites in place:
+
+- AWS CLI configured with access to your AWS account.
+- Docker installed for building images.
+- AWS IAM role with sufficient permissions to create and manage ECS resources.
+- Amazon ECR repository for storing the Docker images.
+- Java JDK 11+ installed locally for development and testing.
+- Maven or Gradle for building the Java project.
+
+### **Architecture Overview**
+
+This guide focuses on deploying the Java container using the following architecture:
+
+```
+project-root/
+├── java-app/
+│   ├── src/                       # Java application source code
+│   ├── main/                      # Main Java files
+│   │   └── java/
+│   │       └── com/
+│   │           └── example/
+│   │               └── javaapp/
+│   │                   ├── JavaAppApplication.java      # Main application class
+│   │                   └── HelloController.java         # REST controller
+│   ├── pom.xml                                          # Maven build configuration
+│   ├── Dockerfile                                       # Dockerfile for Java application
+│   └── opentelemetry-javaagent.jar                      # OpenTelemetry Java agent
+├── ecs/
+│   └── task-definition.json         # ECS task definition file
+└── otel-collector    
+     ├── collector-config.yaml        # OpenTelemetry Collector configuration
+     └── Dockerfile                   # Dockerfile for the Collector
+```
+
+The Java application includes:
+
+- **JavaAppApplication.java**: The main entry point for the Java Spring Boot application.
+- **HelloController.java**: A simple REST controller providing two endpoints.
+- **Dockerfile**: Used to create a Docker image for the Java application.
+- **pom.xml**: Contains Maven build configuration and dependencies.
+- **opentelemetry-javaagent.jar**: The OpenTelemetry Java agent for automatic instrumentation.
+
+### **Code**
+
+#### **JavaAppApplication.java**
+
+```java
+package com.example.javaapp;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class JavaAppApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(JavaAppApplication.class, args);
+    }
+}
+```
+
+This is the main entry point for the Spring Boot application.
+
+#### **HelloController.java**
+
+```java
+package com.example.javaapp;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+    @GetMapping("/")
+    public String index() {
+        return "Hello from the instrumented Java app!";
+    }
+
+    @GetMapping("/hello")
+    public String hello(@RequestParam(value = "name", defaultValue = "World") String name) {
+        return "Hello, " + name + "!";
+    }
+}
+```
+
+This REST controller provides two simple endpoints: `/` and `/hello`.
+
+#### **Dockerfile**
+
+```dockerfile
+# Use a Maven image to build the application
+FROM maven:3.8.6-openjdk-11-slim AS builder
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the project files
+COPY pom.xml .
+COPY src ./src
+
+# Package the application
+RUN mvn clean package -DskipTests
+
+# Use a lightweight OpenJDK image for the runtime
+FROM openjdk:11-jre-slim
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the packaged application and the OpenTelemetry agent
+COPY --from=builder /app/target/java-app-0.0.1-SNAPSHOT.jar app.jar
+COPY opentelemetry-javaagent.jar opentelemetry-javaagent.jar
+
+# Expose the application port
+EXPOSE 8080
+
+# Set environment variables for OpenTelemetry
+ENV OTEL_TRACES_SAMPLER=always_on
+ENV OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
+ENV OTEL_RESOURCE_ATTRIBUTES="service.name=java-app"
+
+# Start the application with the OpenTelemetry Java agent
+ENTRYPOINT ["java", "-javaagent:/app/opentelemetry-javaagent.jar", "-jar", "app.jar"]
+
+```
+
+The Dockerfile uses a multi-stage build approach with a Maven image to build the application, and then a slim OpenJDK image to run it. It sets up the required files, sets environment variables for OpenTelemetry, and starts the application with the OpenTelemetry Java agent for tracing.
+
+#### **pom.xml**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>java-app</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>java-app</name>
+    <description>Demo Java application with OpenTelemetry instrumentation</description>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.7.5</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>11</java.version>
+    </properties>
+
+    <dependencies>
+        <!-- Spring Boot Web Starter -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Optional: For health checks -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Spring Boot Maven Plugin -->
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <executable>true</executable>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+```
+
+This file includes the Maven build configuration for the Java Spring Boot application.
+
+#### **collector-config.yaml**
+
+{@include: ../../_include/log-shipping/tracing-shipping/collector-config.md}
+
+This configuration file defines the OpenTelemetry Collector, specifying how to receive, process, and export traces to Logz.io.
+
+#### **task-definition.json**
+
+```json
+{
+  "family": "java-app-task",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "256",
+  "memory": "512",
+  "executionRoleArn": "arn:aws:iam::<aws_account_id>:role/ecsTaskExecutionRole",
+  "containerDefinitions": [
+    {
+      "name": "java-app",
+      "image": "<aws_account_id>.dkr.ecr.<region>.amazonaws.com/java-app:latest",
+      "cpu": 128,
+      "portMappings": [
+        {
+          "containerPort": 8080,
+          "protocol": "tcp"
+        }
+      ],
+      "essential": true,      
+      "environment": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/java-app",
+          "awslogs-region": "<aws-region>",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    },
+    {
+      "name": "otel-collector",
+      "image": "<aws_account_id>.dkr.ecr.<aws-region>.amazonaws.com/otel-collector:latest",
+      "cpu": 128,      
+      "essential": false,
+      "command": ["--config=/etc/collector-config.yaml"],
+      "environment": [
+        {
+          "name": "LOGZIO_TRACING_TOKEN",
+          "value": "<logzio_tracing_token>"
+        },
+        {
+          "name": "LOGZIO_REGION",
+          "value": "<logzio_region>"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/otel-collector",
+          "awslogs-region": "<aws-region>",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    }
+  ]
+}
+```
+
+This task definition includes both the Java application container and the OpenTelemetry Collector container, defining their configurations and log groups.
+
+### **Step-by-Step Instructions**
+
+#### **1. Project Structure Setup**
+
+Ensure the project structure follows the provided architecture. The Java application source code should be located in the `java-app/` directory.
+
+#### **2. Create an Amazon ECR Repository**
+
+Create an Amazon ECR repository to store the Docker image for the Java application:
+
+```sh
+aws ecr create-repository --repository-name java-app --region <aws-region>
+```
+
+#### **3. Configure OpenTelemetry Collector**
+
+The `collector-config.yaml` in the `ecs/` directory defines the OpenTelemetry Collector configuration for receiving, processing, and exporting telemetry data. The Java application will use OpenTelemetry instrumentation to send traces to the collector running as a sidecar in the ECS task.
+
+**collector-config.yaml**
+
+{@include: ../../_include/log-shipping/tracing-shipping/collector-config.md}
+
+This configuration file defines the OpenTelemetry Collector, specifying how to receive, process, and export traces to Logz.io.
+
+**Dockerfile**
+
+```sh
+# Dockerfile for OpenTelemetry Collector
+FROM otel/opentelemetry-collector-contrib:latest
+COPY collector-config.yaml /etc/collector-config.yaml
+CMD ["--config", "/etc/collector-config.yaml"]
+```
+
+#### **4. Build and Push the Docker Image**
+
+To build the Docker image for the Java application and opentelemetry collector, use the following commands:
+
+```sh
+cd java-app/
+docker build --platform linux/amd64 -t java-app:latest .
+
+cd otel-collector/
+docker build --platform linux/amd64 -t otel-collector:latest .
+```
+
+Next, push the image to your Amazon ECR repository:
+
+```sh
+# Authenticate Docker to your Amazon ECR repository
+aws ecr get-login-password --region <aws-region> | docker login --username AWS --password-stdin <aws_account_id>.dkr.ecr.<region>.amazonaws.com
+
+# Tag and push the images
+docker tag java-app:latest <aws_account_id>.dkr.ecr.<region>.amazonaws.com/java-app:latest
+docker push <aws_account_id>.dkr.ecr.<region>.amazonaws.com/java-app:latest
+
+docker tag otel-collector:latest <aws_account_id>.dkr.ecr.<region>.amazonaws.com/otel-collector:latest
+docker push <aws_account_id>.dkr.ecr.<region>.amazonaws.com/otel-collector:latest
+```
+
+#### **5. Set Up CloudWatch Log Groups**
+
+- **Log Group Creation**: Create log groups for your Java application and OpenTelemetry Collector in CloudWatch.
+
+```sh
+aws logs create-log-group --log-group-name /ecs/java-app
+aws logs create-log-group --log-group-name /ecs/otel-collector
+```
+
+- Ensure the ECS task definition is configured to send logs to the appropriate log groups using the `awslogs` log driver.
+
+#### **6. Create an ECS Cluster and Service**
+
+- **Create ECS Cluster**: Create an ECS cluster using the following command:
+
+```sh
+aws ecs create-cluster --cluster-name <cluster-name> --region <aws-region>
+```
+
+- **Create ECS Service**: Use the ECS cluster to create a service based on the registered task definition.
+
+```sh
+aws ecs create-service \
+  --cluster <cluster-name> \
+  --service-name <service-name> \
+  --task-definition java-app-task \
+  --desired-count 1 \
+  --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[\"YOUR_SUBNET_ID\"],securityGroups=[\"YOUR_SECURITY_GROUP_ID\"],assignPublicIp=ENABLED}" \
+  --region <aws-region> \
+```
+- **Register Task Definition**: Use the `task-definition.json` file located in the `ecs/` directory to register a new task definition for your Java application.
+
+```sh
+aws ecs register-task-definition --cli-input-json file://ecs/task-definition.json
+```
+
+#### **7. Update ECS Service**
+
+After making changes to the container or ECS configuration, update your ECS service to force a new deployment and pull the latest image:
+
+```sh
+aws ecs update-service \
+  --cluster <cluster-name> \
+  --service-name java-app-service \
+  --force-new-deployment \
+  --region <aws-region>
+```
+
+#### **8. Send Requests to the Application**
+
+To verify that the application is working and traces are being collected, use `curl` or a web browser to send requests to the Java application:
+
+```sh
+curl http://<public-ip>:8080/
+curl http://<public-ip>:8080/hello
+```
+
+### **Create Cluster and Service, Update Services**
+
+Ensure you have created the ECS cluster and registered the service with the correct task definition. Whenever updates are made (e.g., new Docker image versions or configuration changes), force a new deployment to apply the changes.

--- a/docs/shipping/Code/node-js.md
+++ b/docs/shipping/Code/node-js.md
@@ -930,6 +930,399 @@ helm uninstall logzio-k8s-telemetry
 </TabItem>
 </Tabs>
 
+## Node.js Application Setup for ECS Service with OpenTelemetry
+
+This document provides step-by-step instructions for setting up a Node.js application on Amazon ECS, using OpenTelemetry to send tracing data directly to your Logz.io account.
+
+### **Prerequisites**
+
+Before you begin, ensure you have the following prerequisites in place:
+
+- AWS CLI configured with access to your AWS account.
+- Docker installed for building images.
+- AWS IAM role with sufficient permissions to create and manage ECS resources.
+- Amazon ECR repository for storing the Docker images.
+- Node.js and npm installed locally for development and testing.
+
+### **Architecture Overview**
+
+This guide focuses on deploying the Node.js container using the following architecture:
+
+```
+project-root/
+├── nodejs-app/
+│   ├── app.js                       # Node.js application code
+│   ├── tracing.js                   # OpenTelemetry tracing setup for Node.js
+│   ├── Dockerfile                   # Dockerfile for Node.js application
+│   └── package.json                 # Node.js dependencies, includes OpenTelemetry
+├── ecs/
+│   └── task-definition.json         # ECS task definition file
+└── otel-collector    
+     ├── collector-config.yaml        # OpenTelemetry Collector configuration
+     └── Dockerfile                   # Dockerfile for the Collector
+
+```
+
+The Node.js application includes:
+
+- **app.js**: A simple Node.js application using Express, with manual OpenTelemetry instrumentation.
+- **tracing.js**: Sets up the OpenTelemetry tracing for the application.
+- **Dockerfile**: Used to create a Docker image for the Node.js application.
+- **package.json**: Lists the required Node.js dependencies, including OpenTelemetry for tracing.
+
+### **Code**
+
+#### **app.py**
+ 
+ ```javascript
+// app.js
+
+const express = require('express');
+const { startTracing } = require('./tracing');
+
+// Start tracing before any other code
+startTracing();
+
+// Import the OpenTelemetry API
+const { trace } = require('@opentelemetry/api');
+
+// Get a tracer
+const tracer = trace.getTracer('nodejs-app');
+
+const app = express();
+const port = 3000;
+
+// Middleware to create a root span for each request
+app.use((req, res, next) => {
+  const span = tracer.startSpan(`HTTP ${req.method} ${req.path}`);
+  // Attach the span to the request object so we can use it in routes
+  req.span = span;
+  // Ensure the span ends when the response is finished
+  res.on('finish', () => {
+    span.end();
+  });
+  next();
+});
+
+app.get('/', (req, res) => {
+  // Use the span from the middleware
+  const span = req.span;
+  span.addEvent('Handling / request');
+  res.send('Hello from the instrumented Node.js app!');
+});
+
+app.get('/hello', (req, res) => {
+  const span = req.span;
+  span.addEvent('Handling /hello request');
+  const name = req.query.name || 'World';
+
+  // Start a child span for some operation (e.g., processing data)
+  const childSpan = tracer.startSpan('processData', {
+    parent: span,
+  });
+  // Simulate some processing
+  childSpan.addEvent('Processing data');
+  // ... your processing logic here
+  childSpan.end();
+
+  res.send(`Hello, ${name}!`);
+});
+
+app.listen(port, () => {
+  console.log(`Node.js app listening at http://localhost:${port}`);
+});
+
+ ```
+
+The above code sets up a simple Express application with middleware that automatically creates spans for each incoming HTTP request and uses OpenTelemetry for tracing, allowing you to trace the request lifecycle more effectively.
+
+#### **tracing.js**
+
+```javascript
+'use strict';
+
+const { NodeSDK } = require('@opentelemetry/sdk-node');
+const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-grpc');
+const { diag, DiagConsoleLogger, DiagLogLevel } = require('@opentelemetry/api');
+const { Resource } = require('@opentelemetry/resources');
+
+// Optional: Enable diagnostic logging for debugging
+diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
+
+function startTracing() {
+  const traceExporter = new OTLPTraceExporter({
+    url: process.env.OTEL_EXPORTER_OTLP_ENDPOINT || 'grpc://localhost:4317',
+  });
+
+  const sdk = new NodeSDK({
+    traceExporter,
+    resource: new Resource({
+      'service.name': 'nodejs-app',
+    }),
+  });
+
+  sdk.start()
+    .then(() => console.log('Tracing initialized'))
+    .catch((error) => console.log('Error initializing tracing', error));
+
+  // Optional: Gracefully shutdown tracing on process exit
+  process.on('SIGTERM', () => {
+    sdk.shutdown()
+      .then(() => console.log('Tracing terminated'))
+      .catch((error) => console.log('Error terminating tracing', error))
+      .finally(() => process.exit(0));
+  });
+}
+
+module.exports = { startTracing };
+```
+
+The `tracing.js` file initializes OpenTelemetry tracing, configuring the OTLP exporter to send trace data to the OpenTelemetry Collector.
+
+#### **Dockerfile**
+
+```dockerfile
+# Use Node.js LTS version
+FROM node:16-alpine
+
+# Set the working directory
+WORKDIR /app
+
+# Copy package.json and package-lock.json
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install --production
+
+# Copy the application code
+COPY . .
+
+# Expose the application port
+EXPOSE 3000
+
+# Set environment variables for OpenTelemetry
+ENV OTEL_TRACES_SAMPLER=always_on
+ENV OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+ENV OTEL_RESOURCE_ATTRIBUTES="service.name=nodejs-app"
+
+# Start the application
+CMD ["npm", "start"]
+```
+
+The Dockerfile uses an Alpine-based Node.js image, installs the necessary dependencies, sets the environment variables required for OpenTelemetry configuration, and starts the application.
+
+#### **package.json**
+
+```json
+{
+  "name": "nodejs-app",
+  "version": "1.0.0",
+  "description": "Demo Node.js application with OpenTelemetry instrumentation",
+  "main": "app.js",
+  "scripts": {
+    "start": "node app.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "^0.52.1",
+    "@opentelemetry/sdk-node": "^0.52.1",
+    "express": "^4.21.1"
+  }
+}
+
+```
+
+This file lists the required dependencies, including Express and OpenTelemetry packages for tracing.
+
+#### **task-definition.json**
+
+```json
+{
+  "family": "nodejs-app-task",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "256",
+  "memory": "512",
+  "executionRoleArn": "arn:aws:iam::<aws_account_id>:role/ecsTaskExecutionRole",
+  "containerDefinitions": [
+    {
+      "name": "nodejs-app",
+      "image": "<aws_account_id>.dkr.ecr.<region>.amazonaws.com/nodejs-app:latest",
+      "cpu": 128,
+      "portMappings": [
+        {
+          "containerPort": 3000,
+          "protocol": "tcp"
+        }
+      ],
+      "essential": true,
+      "environment": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/nodejs-app",
+          "awslogs-region": "<aws-region>",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    },
+    {
+      "name": "otel-collector",
+      "image": "<aws_account_id>.dkr.ecr.<aws-region>.amazonaws.com/otel-collector:latest",
+      "cpu": 128,
+      "essential": false,
+      "command": ["--config=/etc/collector-config.yaml"],
+      "environment": [
+        {
+          "name": "LOGZIO_TRACING_TOKEN",
+          "value": "<logzio_tracing_token>"
+        },
+        {
+          "name": "LOGZIO_REGION",
+          "value": "<logzio_region>"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/otel-collector",
+          "awslogs-region": "<aws-region>",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    }
+  ]
+}
+```
+
+This task definition includes both the Node.js application container and the OpenTelemetry Collector container, defining their configurations and log groups.
+
+### **Step-by-Step Instructions**
+
+#### **1. Project Structure Setup**
+
+Ensure the project structure follows the provided architecture. The Node.js application source code should be located in the `nodejs-app/` directory.
+
+#### **2. Create an Amazon ECR Repository**
+
+Create an Amazon ECR repository to store the Docker image for the Node.js application:
+
+```sh
+aws ecr create-repository --repository-name nodejs-app --region <aws-region>
+```
+
+#### **3. Configure OpenTelemetry Collector**
+
+The `collector-config.yaml` in the `ecs/` directory defines the OpenTelemetry Collector configuration for receiving, processing, and exporting telemetry data. The Node.js application will use OpenTelemetry instrumentation to send traces to the collector running as a sidecar in the ECS task.
+
+**collector-config.yaml**
+
+{@include: ../../_include/log-shipping/tracing-shipping/collector-config.md}
+
+This configuration file defines the OpenTelemetry Collector, specifying how to receive, process, and export traces to Logz.io.
+
+**Dockerfile**
+
+```sh
+# Dockerfile for OpenTelemetry Collector
+FROM otel/opentelemetry-collector-contrib:latest
+COPY collector-config.yaml /etc/collector-config.yaml
+CMD ["--config", "/etc/collector-config.yaml"]
+```
+
+#### **4. Build and Push the Docker Image**
+
+To build the Docker image for the Node.js application and OpenTelemetry Collector, use the following commands:
+
+```sh
+cd nodejs-app/
+docker build --platform linux/amd64 -t nodejs-app:latest .
+
+cd otel-collector/
+docker build --platform linux/amd64 -t otel-collector:latest .
+```
+
+Next, push the images to your Amazon ECR repository:
+
+```sh
+# Authenticate Docker to your Amazon ECR repository
+aws ecr get-login-password --region <aws-region> | docker login --username AWS --password-stdin <aws_account_id>.dkr.ecr.<region>.amazonaws.com
+
+# Tag and push the images
+docker tag nodejs-app:latest <aws_account_id>.dkr.ecr.<region>.amazonaws.com/nodejs-app:latest
+docker push <aws_account_id>.dkr.ecr.<region>.amazonaws.com/nodejs-app:latest
+
+docker tag otel-collector:latest <aws_account_id>.dkr.ecr.<region>.amazonaws.com/otel-collector:latest
+docker push <aws_account_id>.dkr.ecr.<region>.amazonaws.com/otel-collector:latest
+```
+
+#### **5. Set Up CloudWatch Log Groups**
+
+- **Log Group Creation**: Create log groups for your Node.js application and OpenTelemetry Collector in CloudWatch.
+
+```sh
+aws logs create-log-group --log-group-name /ecs/nodejs-app
+aws logs create-log-group --log-group-name /ecs/otel-collector
+```
+
+- Ensure the ECS task definition is configured to send logs to the appropriate log groups using the `awslogs` log driver.
+
+#### **6. Create an ECS Cluster and Service**
+
+- **Create ECS Cluster**: Create an ECS cluster using the following command:
+
+```sh
+aws ecs create-cluster --cluster-name app-cluster --region <aws-region>
+```
+
+- **Create ECS Service**: Use the ECS cluster to create a service based on the registered task definition.
+
+```sh
+aws ecs create-service \
+  --cluster <cluster-name> \
+  --service-name <service-name> \
+  --task-definition nodejs-app-task \
+  --desired-count 1 \
+  --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[\"YOUR_SUBNET_ID\"],securityGroups=[\"YOUR_SECURITY_GROUP_ID\"],assignPublicIp=ENABLED}" \
+  --region <aws-region> \
+```
+
+- **Register Task Definition**: Use the `task-definition.json` file located in the `ecs/` directory to register a new task definition for your Node.js application.
+
+```sh
+aws ecs register-task-definition --cli-input-json file://ecs/task-definition.json
+```
+
+#### **7. Update ECS Service**
+
+After making changes to the container or ECS configuration, update your ECS service to force a new deployment and pull the latest image:
+
+```sh
+aws ecs update-service \
+  --cluster <cluster-name> \
+  --service-name nodejs-app-service \
+  --force-new-deployment \
+  --region <aws-region>
+```
+
+#### **8. Send Requests to the Application**
+
+To verify that the application is working and traces are being collected, use `curl` or a web browser to send requests to the Node.js application:
+
+```sh
+curl http://<public-ip>:3000/
+curl http://<public-ip>:3000/hello
+```
+
+### **Create Cluster and Service, Update Services**
+
+Ensure you have created the ECS cluster and registered the service with the correct task definition. Whenever updates are made (e.g., new Docker image versions or configuration changes), force a new deployment to apply the changes.
+
+---
 
 {@include: ../../_include/tracing-shipping/otel-troubleshooting.md}
 

--- a/docs/shipping/Code/python.md
+++ b/docs/shipping/Code/python.md
@@ -1343,9 +1343,288 @@ Replace `<<YOUR-APPLICATION-SCRIPT>>` with your Python application script name.
 
 Give your traces time to process, after which they'll be available in your [Tracing](https://app.logz.io/#/dashboard/jaeger) dashboard.
 
+## Python Application Setup for ECS Service with OpenTelemetry
 
+This document provides step-by-step instructions for setting up a Python application on Amazon ECS, using OpenTelemetry to send tracing data directly to your Logz.io account.
 
+### **Prerequisites**
 
+Before you begin, ensure you have the following prerequisites in place:
+
+- AWS CLI configured with access to your AWS account.
+- Docker installed for building images.
+- AWS IAM role with sufficient permissions to create and manage ECS resources.
+- Amazon ECR repository for storing the Docker images.
+- Python 3.x and pip installed locally for development and testing.
+
+### **Architecture Overview**
+
+This guide focuses on deploying the Python container using the following architecture:
+
+```
+project-root/
+├── python-app/
+│   ├── app.py                       # Python application code
+│   ├── Dockerfile                   # Dockerfile for Python application
+│   └── requirements.txt             # Python dependencies, includes OpenTelemetry
+├── ecs/
+│   └── task-definition.json         # ECS task definition file
+└── otel-collector    
+     ├── collector-config.yaml        # OpenTelemetry Collector configuration
+     └── Dockerfile                   # Dockerfile for the Collector
+```
+
+The Python application includes:
+
+- **app.py**: A simple Python application using Flask, instrumented with OpenTelemetry for distributed tracing.
+- **Dockerfile**: Used to create a Docker image for the Python application.
+- **requirements.txt**: Lists the required Python dependencies, including OpenTelemetry for tracing.
+
+### **Code**
+
+#### **app.py**
+
+```python
+from flask import Flask, request
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return "Hello from the instrumented Python app!"
+
+@app.route('/hello')
+def hello():
+    name = request.args.get('name', 'World')
+    return f"Hello, {name}!"
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)
+```
+
+The above code sets up a simple Flask application.
+
+#### **Dockerfile**
+
+```dockerfile
+FROM python:3.8-slim
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Set environment variables for OpenTelemetry configuration
+ENV OTEL_TRACES_SAMPLER=always_on
+ENV OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+ENV OTEL_RESOURCE_ATTRIBUTES="service.name=python-app"
+
+EXPOSE 5000
+
+CMD ["opentelemetry-instrument", "python", "app.py"]
+
+```
+
+The Dockerfile uses a slim Python image, installs the necessary dependencies, sets the environment variables required for OpenTelemetry configuration, and starts the application with OpenTelemetry instrumentation.
+
+#### **requirements.txt**
+
+```
+flask
+opentelemetry-distro
+opentelemetry-exporter-otlp
+opentelemetry-instrumentation-flask
+```
+
+This file lists the required dependencies, including Flask and OpenTelemetry packages for tracing. The `opentelemetry-instrumentation-flask` package is used to automatically instrument Flask applications, enabling tracing for incoming HTTP requests without requiring manual instrumentation of each route.
+
+#### **task-definition.json**
+
+```json
+{
+  "family": "python-app-task",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "256",
+  "memory": "512",
+  "executionRoleArn": "arn:aws:iam::<aws_account_id>:role/ecsTaskExecutionRole",
+  "containerDefinitions": [
+    {
+      "name": "python-app",
+      "image": "<aws_account_id>.dkr.ecr.<region>.amazonaws.com/python-app:latest",
+      "cpu": 128,
+      "portMappings": [
+        {
+          "containerPort": 5000,
+          "protocol": "tcp"
+        }
+      ],
+      "essential": true,      
+      "environment": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/python-app",
+          "awslogs-region": "<aws-region>",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    },
+    {
+      "name": "otel-collector",
+      "image": "<aws_account_id>.dkr.ecr.<aws-region>.amazonaws.com/otel-collector:latest",
+      "cpu": 128,      
+      "essential": false,
+      "command": ["--config=/etc/collector-config.yaml"],
+      "environment": [
+        {
+          "name": "LOGZIO_TRACING_TOKEN",
+          "value": "<logzio_tracing_token>"
+        },
+        {
+          "name": "LOGZIO_REGION",
+          "value": "<logzio_region>"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/otel-collector",
+          "awslogs-region": "<aws-region>",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    }
+  ]
+}
+```
+
+This task definition includes both the Python application container and the OpenTelemetry Collector container, defining their configurations and log groups.
+
+### **Step-by-Step Instructions**
+
+#### **1. Project Structure Setup**
+
+Ensure the project structure follows the provided architecture. The Python application source code should be located in the `python-app/` directory.
+
+#### **2. Create an Amazon ECR Repository**
+
+Create an Amazon ECR repository to store the Docker image for the Python application:
+
+```sh
+aws ecr create-repository --repository-name python-app --region <aws-region>
+```
+
+#### **3. Configure OpenTelemetry Collector**
+
+The `collector-config.yaml` in the `ecs/` directory defines the OpenTelemetry Collector configuration for receiving, processing, and exporting telemetry data. The Python application will use OpenTelemetry instrumentation to send traces to the collector running as a sidecar in the ECS task.
+
+**collector-config.yaml**
+
+{@include: ../../_include/log-shipping/tracing-shipping/collector-config.md}
+
+This configuration file defines the OpenTelemetry Collector, specifying how to receive, process, and export traces to Logz.io.
+
+**Dockerfile**
+
+```sh
+# Dockerfile for OpenTelemetry Collector
+FROM otel/opentelemetry-collector-contrib:latest
+COPY collector-config.yaml /etc/collector-config.yaml
+CMD ["--config", "/etc/collector-config.yaml"]
+```
+
+#### **4. Build and Push the Docker Image**
+
+To build the Docker image for the Python application and opentelemetry collector, use the following commands:
+
+```sh
+cd python-app/
+docker build --platform linux/amd64 -t python-app:latest .
+
+cd otel-collector/
+docker build --platform linux/amd64 -t otel-collector:latest .
+```
+
+Next, push the images to your Amazon ECR repository:
+
+```sh
+# Authenticate Docker to your Amazon ECR repository
+aws ecr get-login-password --region <aws-region> | docker login --username AWS --password-stdin <aws_account_id>.dkr.ecr.<region>.amazonaws.com
+
+# Tag and push the images
+docker tag python-app:latest <aws_account_id>.dkr.ecr.<region>.amazonaws.com/python-app:latest
+docker push <aws_account_id>.dkr.ecr.<region>.amazonaws.com/python-app:latest
+
+docker tag otel-collector:latest <aws_account_id>.dkr.ecr.<region>.amazonaws.com/otel-collector:latest
+docker push <aws_account_id>.dkr.ecr.<region>.amazonaws.com/otel-collector:latest
+```
+
+#### **5. Set Up CloudWatch Log Groups**
+
+- **Log Group Creation**: Create log groups for your Python application and OpenTelemetry Collector in CloudWatch.
+
+```sh
+aws logs create-log-group --log-group-name /ecs/python-app
+aws logs create-log-group --log-group-name /ecs/otel-collector
+```
+
+- Ensure the ECS task definition is configured to send logs to the appropriate log groups using the `awslogs` log driver.
+
+#### **6. Create an ECS Cluster and Service**
+
+- **Create ECS Cluster**: Create an ECS cluster using the following command:
+
+```sh
+aws ecs create-cluster --cluster-name app-cluster --region <aws-region> 
+```
+
+- **Create ECS Service**: Use the ECS cluster to create a service based on the registered task definition.
+
+```sh
+aws ecs create-service \
+  --cluster <cluster-name> \
+  --service-name <service-name> \
+  --task-definition python-app-task \
+  --desired-count 1 \
+  --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[\"YOUR_SUBNET_ID\"],securityGroups=[\"YOUR_SECURITY_GROUP_ID\"],assignPublicIp=ENABLED}" \
+  --region <aws-region> \
+```
+
+- **Register Task Definition**: Use the `task-definition.json` file located in the `ecs/` directory to register a new task definition for your Python application.
+
+```sh
+aws ecs register-task-definition --cli-input-json file://ecs/task-definition.json
+```
+
+#### **7. Update ECS Service**
+
+After making changes to the container or ECS configuration, update your ECS service to force a new deployment and pull the latest image:
+
+```sh
+aws ecs update-service \
+  --cluster <cluster-name> \
+  --service-name python-app-service \
+  --force-new-deployment \
+  --region <aws-region>
+```
+
+#### **8. Send Requests to the Application**
+
+To verify that the application is working and traces are being collected, use `curl` or a web browser to send requests to the Python application:
+
+```sh
+curl http://<public-ip>:5000/
+curl http://<public-ip>:5000/hello
+```
+
+### **Create Cluster and Service, Update Services**
+
+Ensure you have created the ECS cluster and registered the service with the correct task definition. Whenever updates are made (e.g., new Docker image versions or configuration changes), force a new deployment to apply the changes.
+
+---
 
 ### Kuberenetes Python application auto insturmentation 
 


### PR DESCRIPTION
Added comprehensive setup documentation for deploying ECS services with OpenTelemetry instrumentation for Java, Python, and Node.js applications. 
Each language has dedicated instructions, including code, Dockerfiles, OpenTelemetry configuration, and ECS task definitions. 

This documentation aids users in configuring distributed tracing with Logz.io as the telemetry endpoint.
