### PR TITLE
Add tolerations doc with zsh fix

### DIFF
--- a/docs/_include/general-shipping/k8s.md
+++ b/docs/_include/general-shipping/k8s.md
@@ -443,6 +443,63 @@ If `10s` is insufficient, try increasing it to `15s` or higher.
 :::
 
  </TabItem>
+
+<TabItem value="adding-toleration" label="Adding Toleration" default>
+
+## Adding Tolerations for Tainted Nodes
+
+To ensure that your pods can be scheduled on nodes with taints, you need to add tolerations to the relevant sub-charts. Here is how you can configure tolerations for each sub-chart within the `logzio-monitoring` Helm chart:
+
+1. **Identify the taints on your nodes:**
+   ```shell
+   kubectl get nodes -o json | jq '"\(.items[].metadata.name) \(.items[].spec.taints)"'
+   ```
+2. **Add tolerations to the Helm install command**:
+You can add tolerations by using the --set flag in your helm install command. Replace the placeholders with your taint values.
+- For `logzio-logs-collector`:
+```shell
+--set 'logzio-logs-collector.tolerations[0].key=<<TAINT-KEY>>' \
+--set 'logzio-logs-collector.tolerations[0].operator=<<TAINT-OPERATOR>>' \
+--set 'logzio-logs-collector.tolerations[0].value=<<TAINT-VALUE>>' \
+--set 'logzio-logs-collector.tolerations[0].effect=<<TAINT-EFFECT>>'
+```
+- For `logzio-k8s-telemetry`:
+```shell
+--set 'logzio-k8s-telemetry.tolerations[0].key=<<TAINT-KEY>>' \
+--set 'logzio-k8s-telemetry.tolerations[0].operator=<<TAINT-OPERATOR>>' \
+--set 'logzio-k8s-telemetry.tolerations[0].value=<<TAINT-VALUE>>' \
+--set 'logzio-k8s-telemetry.tolerations[0].effect=<<TAINT-EFFECT>>'
+```
+- For `logzio-trivy`:
+```shell
+--set 'logzio-trivy.tolerations[0].key=<<TAINT-KEY>>' \
+--set 'logzio-trivy.tolerations[0].operator=<<TAINT-OPERATOR>>' \
+--set 'logzio-trivy.tolerations[0].value=<<TAINT-VALUE>>' \
+--set 'logzio-trivy.tolerations[0].effect=<<TAINT-EFFECT>>'
+```
+- For `logzio-k8s-events`:
+```shell
+--set 'logzio-k8s-events.tolerations[0].key=<<TAINT-KEY>>' \
+--set 'logzio-k8s-events.tolerations[0].operator=<<TAINT-OPERATOR>>' \
+--set 'logzio-k8s-events.tolerations[0].value=<<TAINT-VALUE>>' \
+--set 'logzio-k8s-events.tolerations[0].effect=<<TAINT-EFFECT>>'
+```
+Replace `<<TAINT-KEY>>`, `<<TAINT-OPERATOR>>`, `<<TAINT-VALUE>>`, and `<<TAINT-EFFECT>>` with the appropriate values for your taints.
+
+For example, if you need to tolerate the CriticalAddonsOnly:NoSchedule taint for the logzio-logs-collector after installation, you could use:
+
+```shell
+helm upgrade -n monitoring \
+  --reuse-values \
+  --set 'logzio-logs-collector.tolerations[0].key=CriticalAddonsOnly' \
+  --set 'logzio-logs-collector.tolerations[0].operator=Exists' \
+  --set 'logzio-logs-collector.tolerations[0].effect=NoSchedule' \
+  logzio-monitoring logzio-helm/logzio-monitoring
+```
+
+By following these steps, you can ensure that your pods are scheduled on nodes with taints by adding the necessary tolerations to the Helm chart configuration.
+
+ </TabItem>
 </Tabs>
 
 


### PR DESCRIPTION
This PR updates the documentation for adding tolerations to ensure compatibility with zsh. Previously, users faced issues due to square brackets being interpreted as glob patterns. The update adds a tab with updated commands that are wrapping --set values in single quotes to prevent errors and includes an example for CriticalAddonsOnly:NoSchedule toleration.