### PR TITLE
Add OpenTelemetry Guide for Jenkins Metrics

### DIFF
--- a/docs/shipping/CI-CD/jenkins.md
+++ b/docs/shipping/CI-CD/jenkins.md
@@ -181,8 +181,7 @@ Before you begin, make sure you have:
 * A **Logz.io account** with access to the Metrics tab.
 * Your **Logz.io Metrics Shipping Token**.
 * Your account's **Logz.io Listener Host**. You can find the correct host for your region in the [Logz.io 
-documentation](https://docs.logz.io/docs/user-guide/admin/hosting-regions/account-region/
-#supported-regions-for-prometheus-metrics).
+documentation](https://docs.logz.io/docs/user-guide/admin/hosting-regions/account-region/#supported-regions-for-prometheus-metrics).
 * **Docker** installed and running (for the Docker setup).
 * **Java 11 or 17** installed on your system (for the Local/Native setup).
 

--- a/docs/shipping/CI-CD/jenkins.md
+++ b/docs/shipping/CI-CD/jenkins.md
@@ -283,7 +283,7 @@ IMAGE // jenkins-otel-config.png
 
 1. Run a Pipeline job a few times to generate metrics.
 2. In Logz.io, open **Metrics › Metrics Explorer**.
-3. Search for metrics starting with `jenkins_` (for example `jenkins_job_duration_milliseconds_sum`, `jenkins_job_success_count`). Seeing these metrics confirms the integration is working.
+3. Search for metrics starting with `jenkins_` (for example `jenkins_queue_waiting`, `jenkins_agents_total`). Seeing these metrics confirms the integration is working.
 
 ### Troubleshooting
 

--- a/docs/shipping/CI-CD/jenkins.md
+++ b/docs/shipping/CI-CD/jenkins.md
@@ -168,8 +168,6 @@ Now you need to configure the input plug-in to enable Telegraf to scrape the Jen
   
   <TabItem value="opentelemetry-collector" label="OpenTelemetry Collector" default>
 
-## Sending Jenkins Metrics to Logz.io with OpenTelemetry
-
 This guide provides step-by-step instructions for configuring a Jenkins server to send metrics to your Logz.io account using the official Jenkins OpenTelemetry plugin and an OpenTelemetry Collector.
 
 We cover two common setup methods: using **Docker** for a containerized environment and a **Local/Native** installation for running directly on a host machine.

--- a/docs/shipping/CI-CD/jenkins.md
+++ b/docs/shipping/CI-CD/jenkins.md
@@ -243,7 +243,9 @@ Choose the installation method that matches your environment.
 
 #### Method B: Local/Native Setup
 
-> **Note:** If you haven't already set up Jenkins, follow the [official Jenkins installation guide](https://www.jenkins.io/doc/book/installing/) for your operating system before proceeding with the steps below.
+:::note
+If you haven't already set up Jenkins, follow the [official Jenkins installation guide](https://www.jenkins.io/doc/book/installing/) for your operating system before proceeding with the steps below.
+:::
 
 1. **Download and run the Collector**
 

--- a/docs/shipping/CI-CD/jenkins.md
+++ b/docs/shipping/CI-CD/jenkins.md
@@ -268,12 +268,17 @@ Choose the installation method that matches your environment.
 
 1. Open `http://localhost:8080` in your browser and finish the Jenkins setup wizard.
 2. Go to **Manage Jenkins › Plugins › Available** and install the **OpenTelemetry** plugin (restart if prompted).
+
+IMAGE // opentelemetry-plugin.png
+
 3. Go to **Manage Jenkins › Configure System › OpenTelemetry** and set:
    * **OTLP Endpoint**
      * Docker setup: `http://otel-collector:4317`
      * Local setup: `http://localhost:4317`
    * **Authentication**: *No Authentication*
 4. Click **Save**.
+
+IMAGE // jenkins-otel-config.png
 
 ### Step 4: Verify the Integration
 
@@ -289,6 +294,8 @@ Choose the installation method that matches your environment.
 | `permission denied` or “malware” warning (Local) | Make the Collector executable (`chmod +x`) and, on macOS, remove the quarantine attribute (`xattr -d com.apple.quarantine <file>`). |
 | `Connection refused` | Ensure the Collector is running and that the OTLP endpoint value matches your setup (`otel-collector` for Docker, `localhost` for Local). |
 | No metrics in Logz.io | Check the listener host and token in `config.yaml` and review Collector logs (`docker logs otel-collector` or terminal output) for exporter errors. |
+
+  </TabItem>
 
 </Tabs>
 

--- a/docs/shipping/CI-CD/jenkins.md
+++ b/docs/shipping/CI-CD/jenkins.md
@@ -121,6 +121,10 @@ If you still don't see your logs, see [Filebeat troubleshooting](https://docs.lo
 
 
 ## Metrics
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 <Tabs>
   <TabItem value="telegraf" label="Telegraf" default>
 To send your Prometheus-format Jenkins metrics to Logz.io, you need to add the **inputs.prometheus** and **outputs.http** plug-ins to your Telegraf configuration file.

--- a/docs/shipping/CI-CD/jenkins.md
+++ b/docs/shipping/CI-CD/jenkins.md
@@ -266,16 +266,16 @@ Choose the installation method that matches your environment.
 1. Open `http://localhost:8080` in your browser and finish the Jenkins setup wizard.
 2. Go to **Manage Jenkins › Plugins › Available** and install the **OpenTelemetry** plugin (restart if prompted).
 
-IMAGE // opentelemetry-plugin.png
+![OpenTelemetry Plugin](https://dytvr9ot2sszz.cloudfront.net/logz-docs/opentelemetry-plugin.png)
 
 3. Go to **Manage Jenkins › Configure System › OpenTelemetry** and set:
    * **OTLP Endpoint**
      * Docker setup: `http://otel-collector:4317`
      * Local setup: `http://localhost:4317`
-   * **Authentication**: *No Authentication*
+   * **Authentication**: *No authentication*
 4. Click **Save**.
 
-IMAGE // jenkins-otel-config.png
+![OpenTelemetry Plugin](https://dytvr9ot2sszz.cloudfront.net/logz-docs/jenkins-otel-config.png)
 
 ### Step 4: Verify the Integration
 


### PR DESCRIPTION
This PR adds a new, officially supported guide for sending Jenkins metrics to Logz.io using the OpenTelemetry plugin and an OpenTelemetry Collector.