### PR TITLE
Fix configuration in vector.md

### DIFF
--- a/docs/shipping/Other/vector.md
+++ b/docs/shipping/Other/vector.md
@@ -44,6 +44,7 @@ Find the complete configuration docs at [http sink](https://vector.dev/docs/refe
   type = "http" # Don't change this setting
   inputs = ["YOUR_SOURCE_ID"]
   encoding.codec = "json" # enum: "json" or "text"
+  framing.method = "newline_delimited"
 
   # More information on uri below this code block
   uri = "https://<<LISTENER-HOST>>:8071/?token=<<LOG-SHIPPING-TOKEN>>&type=vector"


### PR DESCRIPTION
The logz.io server expects logs in JSONL (NDJSON) format; without specifying the `newline_delimited` framing method, logs will be shipped as a JSON array, acknowledged by the server with HTTP status 200, and silently discarded.